### PR TITLE
Serve atlas from developmentseed.org path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: Connectivity Atlas | Development Seed
-baseurl: ""
-url: "https://atlas.developmentseed.org"
+baseurl: "connectivity-atlas"
+url: "https://developmentseed.org"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
atlas.developmentseed.org no longer works after [recent changes](https://github.com/developmentseed/ds-devops/issues/43#issuecomment-1957771310).  This project is served at https://developmentseed.org/connectivity-atlas/ but doesn't work as the application is configured to serve assets from the root when we are now serving it from a path.